### PR TITLE
Abuse the extension system for platform dependencies.

### DIFF
--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,24 @@
+require 'rubygems'
+require 'rubygems/command.rb'
+require 'rubygems/dependency_installer.rb'
+
+begin
+  Gem::Command.build_args = ARGV
+  rescue NoMethodError
+end
+
+inst = Gem::DependencyInstaller.new
+begin
+  if Gem::Platform.local.os == 'linux'
+    inst.install 'ruby-dbus'
+  end
+rescue => e
+  puts 'Dependency installation failed.'
+  puts e.message
+  exit(1)
+end
+
+# mkmf expects a Rakefile to exist
+f = File.open(File.join(File.dirname(__FILE__), 'Rakefile'), 'w')
+f.write("task :default\n")
+f.close

--- a/fidget.gemspec
+++ b/fidget.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("lib/**/*")
   s.files            += Dir.glob("bin/**/*")
 
-  s.add_dependency "ruby-dbus"
+  # Add platform specific dependencies by abusing the extension system.
+  s.extensions = 'ext/mkrf_conf.rb'
 
   s.description       = <<-desc
   Fidget was inspired by the OS X commandline `caffeinate` tool, which in turn
@@ -30,5 +31,6 @@ Gem::Specification.new do |s|
     * Linux with xdg-screensaver (Xorg)
     * Windows
   desc
+
 
 end


### PR DESCRIPTION
A standard `gemspec` won't let us specify dependencies by platform. In
our case, though, we only want to install `ruby-dbus` on Linux. This
pretends to compile a native extension, and just installs the gem if
on the right platform.

Two problems:

* This is non-intuitive and not clear what dependencies exist.
* This will fail (for no real reason) if rake isn't installed.

Is this a good idea? Is there a better way? Should we just say fuggit
and install `ruby-dbus` on all platforms?

What say you, @adrienthebo ?