### PR TITLE
Do not return undefined variable

### DIFF
--- a/lib/fidget/platform/linux.rb
+++ b/lib/fidget/platform/linux.rb
@@ -20,8 +20,6 @@ class Fidget::Platform
       yield
       resume(options)
     end
-
-    pid
   end
 
   def self.allow_sleep


### PR DESCRIPTION
There is no such `pid` variable in this piece of code.