### PR TITLE
Perform an async DBus call

### DIFF
--- a/lib/fidget/platform/linux.rb
+++ b/lib/fidget/platform/linux.rb
@@ -1,5 +1,6 @@
 class Fidget::Platform
   require "dbus"
+  @@cookie = nil
 
   def self.current_process(options)
     return false unless required_binaries
@@ -69,7 +70,9 @@ class Fidget::Platform
       # This is possibly because the inhibit expires when the dbus-session command terminates
       # I don't know if this will work in other distros though. Yay for consistency. *\o/*
       begin
-        @@cookie = dbus_screensaver.Inhibit(root_win, 'Administratively disabled')
+        dbus_screensaver.Inhibit(root_win, 'Administratively disabled') do |res|
+          @@cookie = res
+        end
       rescue => e
         STDERR.puts 'Fidget: DBus action failed.'
         STDERR.puts e.message


### PR DESCRIPTION
Under some circumstances inhibiting the screen saver will block (e.g. a
system with the org.freedesktop.ScreenSaver service provided by Cinnamon
but the current window-manager is not Cinnamon).

Do the call asynchroneously so that fidget is not blocking, and Ctrl+C
will be catched propertly and configuration reset as expected in all
cases.