### PR TITLE
Pin ruby-dbus dependency

### DIFF
--- a/fidget.gemspec
+++ b/fidget.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("lib/**/*")
   s.files            += Dir.glob("bin/**/*")
 
-  s.add_dependency    "ruby-dbus", "<= 0.14.1"
+  s.add_dependency    "ruby-dbus", "< 0.15.0"
 
   s.description       = <<-desc
   Fidget was inspired by the OS X commandline `caffeinate` tool, which in turn

--- a/fidget.gemspec
+++ b/fidget.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files            += Dir.glob("lib/**/*")
   s.files            += Dir.glob("bin/**/*")
 
-  s.add_dependency    "ruby-dbus"
+  s.add_dependency    "ruby-dbus", "<= 0.14.1"
 
   s.description       = <<-desc
   Fidget was inspired by the OS X commandline `caffeinate` tool, which in turn


### PR DESCRIPTION
ruby-dbus 0.15.1 breaks this gem, using Ruby 2.4.1.  Issue seems to be with ruby-dbus not supported above Ruby 2.0 and will follow up there, but pinning this to last known working version in the meantime

```
root@master:~ # showoff
/usr/local/share/gems/gems/ruby-dbus-0.15.0/lib/dbus/core_ext/class/attribute.rb:80:in `block (2 levels) in my_class_attribute': undefined method `singleton_class?' for DBus::Object:Class (NoMethodError)
        from /usr/local/share/gems/gems/ruby-dbus-0.15.0/lib/dbus/export.rb:25:in `<class:Object>'
        from /usr/local/share/gems/gems/ruby-dbus-0.15.0/lib/dbus/export.rb:20:in `<module:DBus>'
        from /usr/local/share/gems/gems/ruby-dbus-0.15.0/lib/dbus/export.rb:14:in `<top (required)>'
        from /usr/local/share/gems/gems/ruby-dbus-0.15.0/lib/dbus.rb:15:in `require_relative'
        from /usr/local/share/gems/gems/ruby-dbus-0.15.0/lib/dbus.rb:15:in `<top (required)>'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/share/gems/gems/fidget-0.0.5/lib/fidget/platform/posix.rb:2:in `<class:Platform>'
        from /usr/local/share/gems/gems/fidget-0.0.5/lib/fidget/platform/posix.rb:1:in `<top (required)>'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/share/gems/gems/fidget-0.0.5/lib/fidget.rb:10:in `<class:Fidget>'
        from /usr/local/share/gems/gems/fidget-0.0.5/lib/fidget.rb:1:in `<top (required)>'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /usr/local/share/gems/gems/showoff-0.19.6/bin/showoff:7:in `<top (required)>'
        from /usr/local/bin/showoff:23:in `load'
        from /usr/local/bin/showoff:23:in `<main>'
```